### PR TITLE
Use Env Vars for Controller Credentials

### DIFF
--- a/generators/app/templates/README.md
+++ b/generators/app/templates/README.md
@@ -18,7 +18,8 @@ When run locally, unless an environment variable is set, the application will ru
 On the server, the app will try to pull, in order, the port number from an environment variable set of `PORT` or `VCAP_APP_PORT`.
 
 ##### Controlling the Presentation
-The node app uses basic auth to protect the _/control_ end point. By default, these credentials (which are embedded in the _/routes/index.js_ file). Their defaults (which you are encouraged to change):
+The node app uses basic auth to protect the _/control_ end point. By default, these credentials (which are embedded in the _/routes/index.js_ file). The values are settable via the `CONTROLLER_NAME` and `CONTROLLER_PW` environment variables, with defaults of :
+
 ```
 username: admin
 password: someAmazingP@$$w0rd

--- a/generators/app/templates/app.js
+++ b/generators/app/templates/app.js
@@ -13,7 +13,7 @@ var express = require('express'),
 
 app.set('views', path.join(__dirname, 'views'))
     .set('view engine', 'ejs')
-    .use(favicon(__dirname + '/public/img/favicon.ico'))
+    .use(favicon(path.join(__dirname, '/public/img/favicon.ico')))
     .use(logger('dev'))
     .use(bodyParser.json())
     .use(bodyParser.urlencoded({

--- a/generators/app/templates/routes/index.js
+++ b/generators/app/templates/routes/index.js
@@ -1,12 +1,14 @@
-var express = require('express');
-var router = express.Router();
-var auth = require('http-auth');
+const express = require('express');
+const router = express.Router();
+const auth = require('http-auth');
+const aUnm = process.env.CONTROLLER_NAME || 'admin';
+const aPw = process.env.CONTROLLER_PW || 'someAmazingP@$$w0rd';
 
 // Configure basic auth
 var basic = auth.basic({
   realm: 'SUPER SECRET STUFF'
 }, function (username, password, callback) {
-  callback(username === 'admin' && password === 'someAmazingP@$$w0rd');
+  callback(username === aUnm && password === aPw);
 });
 
 var authMiddleware = auth.connect(basic);


### PR DESCRIPTION
controller credentials now provisioned with env vars

env vars of CONTROLLER_NAME and CONTROLLER_PW are now available to set controller's credentials, fails over to previous defaults

closes #5